### PR TITLE
API Docs with OpenAPI 2.0 & Swagger UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ typings/
 
 # next.js build output
 .next
+
+# IDE
+.idea/

--- a/app.js
+++ b/app.js
@@ -35,7 +35,7 @@ let options = {
         info: {
             description: 'GT Bits of Good - Bootcamp Project',
             title: 'Reddit Backend',
-            version: '1.0.0',
+            version: '2.0.0',
         },
         basePath: '/api/v1',
         produces: [

--- a/app.js
+++ b/app.js
@@ -37,7 +37,6 @@ let options = {
             title: 'Reddit Backend',
             version: '1.0.0',
         },
-        host: 'localhost:3000',
         basePath: '/api/v1',
         produces: [
             "application/json"

--- a/app.js
+++ b/app.js
@@ -4,11 +4,15 @@ const cookieParser = require("cookie-parser");
 const logger = require("morgan");
 const mongoose = require("mongoose");
 const routes = require("./routes");
+const swaggerUiGenerator = require('express-swagger-generator');
 
 // Load Env Variables
 require("dotenv").config();
 
 const app = express();
+
+// Generate API docs
+const expressSwagger = swaggerUiGenerator(app);
 
 // initiate DB Connection
 mongoose
@@ -24,5 +28,26 @@ app.use(express.urlencoded({ extended: false }));
 app.use(cookieParser());
 app.use(express.static(path.join(__dirname, "public")));
 
-app.use("/", routes);
+app.use("/api/v1/", routes);
+
+let options = {
+    swaggerDefinition: {
+        info: {
+            description: 'GT Bits of Good - Bootcamp Project',
+            title: 'Reddit Backend',
+            version: '1.0.0',
+        },
+        host: 'localhost:3000',
+        basePath: '/api/v1',
+        produces: [
+            "application/json"
+        ],
+        schemes: ['http', 'https'],
+        securityDefinitions: {}
+    },
+    basedir: __dirname, //app absolute path
+    files: ['./routes/**/*.js'] //Path to the API handle folder
+};
+expressSwagger(options);
+
 module.exports = app;

--- a/models/post.js
+++ b/models/post.js
@@ -60,4 +60,4 @@ postSchema.static("findByIdAndAddComment", function(id, commentData) {
     .then(post => this.findById(post.id).populate("comments"));
 });
 
-module.exports = mongoose.model("Post", postSchema);
+module.exports = mongoose.model("PostResponse", postSchema);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,857 @@
+{
+  "name": "bootcamp-reddit",
+  "version": "0.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "accepts": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
+      "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
+      "requires": {
+        "mime-types": "~2.1.18",
+        "negotiator": "0.6.1"
+      }
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+    },
+    "async": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+      "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+      "requires": {
+        "lodash": "^4.17.10"
+      }
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
+    },
+    "bluebird": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+    },
+    "body-parser": {
+      "version": "1.18.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
+      "integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
+      "requires": {
+        "bytes": "3.0.0",
+        "content-type": "~1.0.4",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "http-errors": "~1.6.3",
+        "iconv-lite": "0.4.23",
+        "on-finished": "~2.3.0",
+        "qs": "6.5.2",
+        "raw-body": "2.3.3",
+        "type-is": "~1.6.16"
+      }
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "bson": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.1.tgz",
+      "integrity": "sha512-jCGVYLoYMHDkOsbwJZBCqwMHyH4c+wzgI9hG7Z6SZJRXWr+x58pdIbm2i9a/jFGCkRJqRUr8eoI7lDWa0hTkxg=="
+    },
+    "bytes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
+    },
+    "call-me-maybe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms="
+    },
+    "commander": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
+      "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
+      "optional": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "content-disposition": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+      "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
+    },
+    "content-type": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
+    },
+    "cookie": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+    },
+    "cookie-parser": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.4.tgz",
+      "integrity": "sha512-lo13tqF3JEtFO7FyA49CqbhaFkskRJ0u/UAiINgrIXeRCY41c88/zxtrECl8AKH3B0hj9q10+h3Kt8I7KlW4tw==",
+      "requires": {
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6"
+      }
+    },
+    "cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+    },
+    "core-js": {
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
+      "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A=="
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+    },
+    "destroy": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+    },
+    "doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "requires": {
+        "esutils": "^2.0.2"
+      }
+    },
+    "doctrine-file": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/doctrine-file/-/doctrine-file-1.0.3.tgz",
+      "integrity": "sha512-OK37HbZtNmIMn84riibVXRmcEGUIf6BNfYMcbXg20ejP+LEsf4tnk8QfYy3EmQs4KzZFhTl3zwoKqVwARxpBgA==",
+      "requires": {
+        "doctrine": "^2.0.0"
+      }
+    },
+    "dotenv": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.2.0.tgz",
+      "integrity": "sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w=="
+    },
+    "ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+    },
+    "encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
+    },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+    },
+    "etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+    },
+    "express": {
+      "version": "4.16.4",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.16.4.tgz",
+      "integrity": "sha512-j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==",
+      "requires": {
+        "accepts": "~1.3.5",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.18.3",
+        "content-disposition": "0.5.2",
+        "content-type": "~1.0.4",
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.1.1",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.4",
+        "qs": "6.5.2",
+        "range-parser": "~1.2.0",
+        "safe-buffer": "5.1.2",
+        "send": "0.16.2",
+        "serve-static": "1.13.2",
+        "setprototypeof": "1.1.0",
+        "statuses": "~1.4.0",
+        "type-is": "~1.6.16",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      }
+    },
+    "express-swagger-generator": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/express-swagger-generator/-/express-swagger-generator-1.1.13.tgz",
+      "integrity": "sha512-syQVqFACnWOSF6/3BRpVkrTvdoe0RsEvKPe1LZer2tKOm3g4eUToyjZa0rZaKAHluHB47g1J35+E338VLA+l0w==",
+      "requires": {
+        "doctrine": "^2.0.0",
+        "doctrine-file": "^1.0.2",
+        "express-swaggerize-ui": "^1.0.3",
+        "glob": "^7.0.3",
+        "recursive-iterator": "^2.0.3",
+        "swagger-parser": "^5.0.5"
+      }
+    },
+    "express-swaggerize-ui": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/express-swaggerize-ui/-/express-swaggerize-ui-1.0.4.tgz",
+      "integrity": "sha512-ye07pdQHKBvp9XnWwgEV+qnK5zUmay0ZksmPgCkaoUD5VCUvp/+ItnDvb5fGOsOvecwZN1lCFrujYrMcQ0HLPA==",
+      "requires": {
+        "express": "^4.13.3"
+      }
+    },
+    "finalhandler": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+      "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
+      "requires": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "statuses": "~1.4.0",
+        "unpipe": "~1.0.0"
+      }
+    },
+    "format-util": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/format-util/-/format-util-1.0.3.tgz",
+      "integrity": "sha1-Ay3KShFiYqEsQ/TD7IVmQWxbLZU="
+    },
+    "forwarded": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
+    },
+    "fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "glob": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "http-errors": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+      "requires": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.0",
+        "statuses": ">= 1.4.0 < 2"
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+      "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+    },
+    "ipaddr.js": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
+      "integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4="
+    },
+    "js-yaml": {
+      "version": "3.12.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.2.tgz",
+      "integrity": "sha512-QHn/Lh/7HhZ/Twc7vJYQTkjuCa0kaCcDcjK5Zlk2rvnUpy7DxMJ23+Jc2dcyvltwQVg1nygAVlB2oRDFHoRS5Q==",
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
+    },
+    "json-schema-ref-parser": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-5.1.3.tgz",
+      "integrity": "sha512-CpDFlBwz/6la78hZxyB9FECVKGYjIIl3Ms3KLqFj99W7IIb7D00/RDgc++IGB4BBALl0QRhh5m4q5WNSopvLtQ==",
+      "requires": {
+        "call-me-maybe": "^1.0.1",
+        "debug": "^3.1.0",
+        "js-yaml": "^3.12.0",
+        "ono": "^4.0.6"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
+      }
+    },
+    "jsonschema": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.4.tgz",
+      "integrity": "sha512-lz1nOH69GbsVHeVgEdvyavc/33oymY1AZwtePMiMj4HZPMbP5OIKK3zT9INMWjwua/V4Z4yq7wSlBbSG+g4AEw=="
+    },
+    "jsonschema-draft4": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/jsonschema-draft4/-/jsonschema-draft4-1.0.0.tgz",
+      "integrity": "sha1-8K8gBQVPDwrefqIRhhS2ncUS2GU="
+    },
+    "kareem": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.3.0.tgz",
+      "integrity": "sha512-6hHxsp9e6zQU8nXsP+02HGWXwTkOEw6IROhF2ZA28cYbUk4eJ6QbtZvdqZOdD9YPKghG3apk5eOCvs+tLl3lRg=="
+    },
+    "lodash": {
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+    },
+    "media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+    },
+    "memory-pager": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+      "optional": true
+    },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+    },
+    "methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+    },
+    "mime": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+      "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
+    },
+    "mime-db": {
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.38.0.tgz",
+      "integrity": "sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg=="
+    },
+    "mime-types": {
+      "version": "2.1.22",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.22.tgz",
+      "integrity": "sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==",
+      "requires": {
+        "mime-db": "~1.38.0"
+      }
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "mongodb": {
+      "version": "3.1.13",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.1.13.tgz",
+      "integrity": "sha512-sz2dhvBZQWf3LRNDhbd30KHVzdjZx9IKC0L+kSZ/gzYquCF5zPOgGqRz6sSCqYZtKP2ekB4nfLxhGtzGHnIKxA==",
+      "requires": {
+        "mongodb-core": "3.1.11",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "mongodb-core": {
+      "version": "3.1.11",
+      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-3.1.11.tgz",
+      "integrity": "sha512-rD2US2s5qk/ckbiiGFHeu+yKYDXdJ1G87F6CG3YdaZpzdOm5zpoAZd/EKbPmFO6cQZ+XVXBXBJ660sSI0gc6qg==",
+      "requires": {
+        "bson": "^1.1.0",
+        "require_optional": "^1.0.1",
+        "safe-buffer": "^5.1.2",
+        "saslprep": "^1.0.0"
+      }
+    },
+    "mongoose": {
+      "version": "5.4.19",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.4.19.tgz",
+      "integrity": "sha512-paRU3nbCrPIUVw1GAlxo11uIIqrYORctUx1kcLj7i2NhkxPQuy5OK2/FYj8+tglsaixycmONSyop2HQp1IUQSA==",
+      "requires": {
+        "async": "2.6.1",
+        "bson": "~1.1.0",
+        "kareem": "2.3.0",
+        "mongodb": "3.1.13",
+        "mongodb-core": "3.1.11",
+        "mongoose-legacy-pluralize": "1.0.2",
+        "mpath": "0.5.1",
+        "mquery": "3.2.0",
+        "ms": "2.1.1",
+        "regexp-clone": "0.0.1",
+        "safe-buffer": "5.1.2",
+        "sliced": "1.0.1"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
+      }
+    },
+    "mongoose-legacy-pluralize": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/mongoose-legacy-pluralize/-/mongoose-legacy-pluralize-1.0.2.tgz",
+      "integrity": "sha512-Yo/7qQU4/EyIS8YDFSeenIvXxZN+ld7YdV9LqFVQJzTLye8unujAWPZ4NWKfFA+RNjh+wvTWKY9Z3E5XM6ZZiQ=="
+    },
+    "morgan": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.9.1.tgz",
+      "integrity": "sha512-HQStPIV4y3afTiCYVxirakhlCfGkI161c76kKFca7Fk1JusM//Qeo1ej2XaMniiNeaZklMVrh3vTtIzpzwbpmA==",
+      "requires": {
+        "basic-auth": "~2.0.0",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "on-headers": "~1.0.1"
+      }
+    },
+    "mpath": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.5.1.tgz",
+      "integrity": "sha512-H8OVQ+QEz82sch4wbODFOz+3YQ61FYz/z3eJ5pIdbMEaUzDqA268Wd+Vt4Paw9TJfvDgVKaayC0gBzMIw2jhsg=="
+    },
+    "mquery": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mquery/-/mquery-3.2.0.tgz",
+      "integrity": "sha512-qPJcdK/yqcbQiKoemAt62Y0BAc0fTEKo1IThodBD+O5meQRJT/2HSe5QpBNwaa4CjskoGrYWsEyjkqgiE0qjhg==",
+      "requires": {
+        "bluebird": "3.5.1",
+        "debug": "3.1.0",
+        "regexp-clone": "0.0.1",
+        "safe-buffer": "5.1.2",
+        "sliced": "1.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "negotiator": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
+    },
+    "on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "requires": {
+        "ee-first": "1.1.1"
+      }
+    },
+    "on-headers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA=="
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "ono": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/ono/-/ono-4.0.11.tgz",
+      "integrity": "sha512-jQ31cORBFE6td25deYeD80wxKBMj+zBmHTrVxnc6CKhx8gho6ipmWM5zj/oeoqioZ99yqBls9Z/9Nss7J26G2g==",
+      "requires": {
+        "format-util": "^1.0.3"
+      }
+    },
+    "openapi-schema-validation": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/openapi-schema-validation/-/openapi-schema-validation-0.4.2.tgz",
+      "integrity": "sha512-K8LqLpkUf2S04p2Nphq9L+3bGFh/kJypxIG2NVGKX0ffzT4NQI9HirhiY6Iurfej9lCu7y4Ndm4tv+lm86Ck7w==",
+      "requires": {
+        "jsonschema": "1.2.4",
+        "jsonschema-draft4": "^1.0.0",
+        "swagger-schema-official": "2.0.0-bab6bed"
+      }
+    },
+    "parseurl": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
+      "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+    },
+    "path-to-regexp": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+    },
+    "proxy-addr": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz",
+      "integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
+      "requires": {
+        "forwarded": "~0.1.2",
+        "ipaddr.js": "1.8.0"
+      }
+    },
+    "qs": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+    },
+    "range-parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
+    },
+    "raw-body": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
+      "integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
+      "requires": {
+        "bytes": "3.0.0",
+        "http-errors": "1.6.3",
+        "iconv-lite": "0.4.23",
+        "unpipe": "1.0.0"
+      }
+    },
+    "recursive-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/recursive-iterator/-/recursive-iterator-2.0.3.tgz",
+      "integrity": "sha1-0ODSx+eoMQnXMJHPBD/FCeWnbcM="
+    },
+    "regexp-clone": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/regexp-clone/-/regexp-clone-0.0.1.tgz",
+      "integrity": "sha1-p8LgmJH9vzj7sQ03b7cwA+aKxYk="
+    },
+    "require_optional": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
+      "integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
+      "requires": {
+        "resolve-from": "^2.0.0",
+        "semver": "^5.1.0"
+      }
+    },
+    "resolve-from": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+      "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "saslprep": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.2.tgz",
+      "integrity": "sha512-4cDsYuAjXssUSjxHKRe4DTZC0agDwsCqcMqtJAQPzC74nJ7LfAJflAtC1Zed5hMzEQKj82d3tuzqdGNRsLJ4Gw==",
+      "optional": true,
+      "requires": {
+        "sparse-bitfield": "^3.0.3"
+      }
+    },
+    "semver": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
+    },
+    "send": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
+      "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+      "requires": {
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "~1.6.2",
+        "mime": "1.4.1",
+        "ms": "2.0.0",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.4.0"
+      }
+    },
+    "serve-static": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
+      "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
+      "requires": {
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.2",
+        "send": "0.16.2"
+      }
+    },
+    "setprototypeof": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
+    },
+    "sliced": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sliced/-/sliced-1.0.1.tgz",
+      "integrity": "sha1-CzpmK10Ewxd7GSa+qCsD+Dei70E="
+    },
+    "sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha1-/0rm5oZWBWuks+eSqzM004JzyhE=",
+      "optional": true,
+      "requires": {
+        "memory-pager": "^1.0.2"
+      }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+    },
+    "statuses": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+      "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
+    },
+    "swagger-methods": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/swagger-methods/-/swagger-methods-1.0.8.tgz",
+      "integrity": "sha512-G6baCwuHA+C5jf4FNOrosE4XlmGsdjbOjdBK4yuiDDj/ro9uR4Srj3OR84oQMT8F3qKp00tYNv0YN730oTHPZA=="
+    },
+    "swagger-parser": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-5.0.6.tgz",
+      "integrity": "sha512-FdzCYFK11iGgrOpojlqUluU6SKThtzmu+5Get+6ValJR2TFwTnES1x4Fdfgy3C4/8VVXk4Va/WsqGlbyY/Os+A==",
+      "requires": {
+        "call-me-maybe": "^1.0.1",
+        "debug": "^3.1.0",
+        "json-schema-ref-parser": "^5.1.3",
+        "ono": "^4.0.6",
+        "openapi-schema-validation": "^0.4.2",
+        "swagger-methods": "^1.0.4",
+        "swagger-schema-official": "2.0.0-bab6bed",
+        "z-schema": "^3.23.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        }
+      }
+    },
+    "swagger-schema-official": {
+      "version": "2.0.0-bab6bed",
+      "resolved": "https://registry.npmjs.org/swagger-schema-official/-/swagger-schema-official-2.0.0-bab6bed.tgz",
+      "integrity": "sha1-cAcEaNbSl3ylI3suUZyn0Gouo/0="
+    },
+    "swagger-ui-dist": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.21.0.tgz",
+      "integrity": "sha512-bAhzzpujhSIXdzpSI9b9RpvahC556lxcOIXxt1OOtTIasYodpy94gDlanQl4j7xavmi4nhaGiZ9iBcoFO+wHlA=="
+    },
+    "swagger-ui-express": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.0.2.tgz",
+      "integrity": "sha512-XZtXI2+SKT3fgvJSGg4P7Dtmkzr50uoSb09IxbUWmjL538TIGRMZtfdEkjZEEq44xgGNAxMryzBEUdUnkXr8dA==",
+      "requires": {
+        "swagger-ui-dist": "^3.18.1"
+      }
+    },
+    "type-is": {
+      "version": "1.6.16",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
+      "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.18"
+      }
+    },
+    "unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+    },
+    "utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+    },
+    "validator": {
+      "version": "10.11.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-10.11.0.tgz",
+      "integrity": "sha512-X/p3UZerAIsbBfN/IwahhYaBbY68EN/UQBWHtsbXGT5bfrH/p4NQzUCG1kF/rtKaNpnJ7jAu6NGTdSNtyNIXMw=="
+    },
+    "vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "z-schema": {
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-3.25.1.tgz",
+      "integrity": "sha512-7tDlwhrBG+oYFdXNOjILSurpfQyuVgkRe3hB2q8TEssamDHB7BbLWYkYO98nTn0FibfdFroFKDjndbgufAgS/Q==",
+      "requires": {
+        "commander": "^2.7.1",
+        "core-js": "^2.5.7",
+        "lodash.get": "^4.0.0",
+        "lodash.isequal": "^4.0.0",
+        "validator": "^10.0.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "debug": "~2.6.9",
     "dotenv": "^6.2.0",
     "express": "~4.16.0",
+    "express-swagger-generator": "^1.1.13",
     "mongoose": "^5.4.16",
     "morgan": "~1.9.0"
   }

--- a/routes/index.js
+++ b/routes/index.js
@@ -13,68 +13,68 @@ router.get("/", (req, res) => {
  * @route GET /posts
  * @group Posts - Operations about posts
  * @operationId getPosts
- * @returns {PostResponse[]} 200 - An array of posts
- * @returns {Error.model}  500 - Unexpected error
+ * @returns {ApiResponseMultiplePosts.model} 200 - An array of posts
+ * @returns {ApiResponseError.model}  500 - Unexpected error in the backend...
  */
 router.get("/posts", controllers.posts.index);
 
 /**
  * Create a new post.
  * @route POST /posts
- * @param {PostRequest.model} post.body.required - the new post
+ * @param {ApiRequestPost.model} post.body.required - The new post
  * @group Posts - Operations about posts
  * @operationId createPost
- * @returns {PostResponse.model} 201 - The new post stored in the database
- * @returns {Error.model}  400 - Schema validation error
- * @returns {Error.model}  500 - Unexpected error
+ * @returns {ApiResponseSinglePost.model} 201 - The new post stored in the database
+ * @returns {ApiResponseError.model}  400 - Schema validation error
+ * @returns {ApiResponseError.model}  500 - Unexpected error in the backend...
  */
 router.post("/posts", controllers.posts.store);
 
 /**
  * Get a specific post.
  * @route GET /posts/:id
- * @param {number} id.path - the post id
+ * @param {number} id.path.required - The post id
  * @group Posts - Operations about posts
  * @operationId getPost
- * @returns {PostResponse.model} 200 - The post with the corresponding id
- * @returns {Error.model}  500 - Unexpected error
+ * @returns {ApiResponseSinglePost.model} 200 - The post with the corresponding id
+ * @returns {ApiResponseError.model}  500 - Unexpected error in the backend...
  */
 router.get("/posts/:id", controllers.posts.get);
 
 /**
  * Edit a specific post.
  * @route PATCH /posts/:id
- * @param {number} id.path - the post id
- * @param {PostRequest.model} post.body.required - the edited post
+ * @param {number} id.path.required - The post id
+ * @param {ApiRequestPost.model} post.body.required - The edited post
  * @group Posts - Operations about posts
  * @operationId editPost
- * @returns {PostResponse.model} 200 - The edited post stored in the database
- * @returns {Error.model}  400 - Schema validation error
- * @returns {Error.model}  500 - Unexpected error
+ * @returns {ApiResponseSinglePost.model} 200 - The edited post stored in the database
+ * @returns {ApiResponseError.model}  400 - Schema validation error
+ * @returns {ApiResponseError.model}  500 - Unexpected error in the backend...
  */
 router.patch("/posts/:id", controllers.posts.update);
 
 /**
  * Delete a specific post.
  * @route DELETE /posts/:id
- * @param {number} id.path - the post id
+ * @param {number} id.path.required - The post id
  * @group Posts - Operations about posts
  * @operationId deletePost
- * @returns {Response} 200 - Successful deletion
- * @returns {Error.model}  500 - Unexpected error
+ * @returns {ApiResponseSuccess.model} 200 - Successful deletion
+ * @returns {ApiResponseSinglePost.model}  500 - Unexpected error in the backend...
  */
 router.delete("/posts/:id", controllers.posts.delete);
 
 /**
  * Create a new top-level comment for the given post.
  * @route POST /posts/:id/comment
- * @param {number} id.path - the post id
- * @param {CommentRequest.model} comment.body.required - the new comment for the post
+ * @param {number} id.path.required - The post id
+ * @param {ApiRequestComment.model} comment.body.required - The new comment for the post
  * @group Posts - Operations about posts
  * @operationId addTopLevelComment
- * @returns {PostResponse.model} 201 - The post with the new comment stored in the database
- * @returns {Error.model}  400 - Schema validation error
- * @returns {Error.model}  500 - Unexpected error
+ * @returns {ApiResponseSinglePost.model} 201 - The post with the new comment stored in the database
+ * @returns {ApiResponseError.model}  400 - Schema validation error
+ * @returns {ApiResponseError.model}  500 - Unexpected error in the backend...
  */
 router.post("/posts/:id/comment", controllers.posts.comment);
 
@@ -83,56 +83,56 @@ router.post("/posts/:id/comment", controllers.posts.comment);
  * @route GET /comments
  * @group Comments - Operations about comments
  * @operationId getComments
- * @returns {CommentResponse[]} 200 - An array of comments
- * @returns {Error.model}  500 - Unexpected error
+ * @returns {ApiResponseMultipleComments.model} 200 - An array of comments
+ * @returns {ApiResponseError.model}  500 - Unexpected error in the backend...
  */
 router.get("/comments", controllers.comments.index);
 
 /**
  * Get a specific comment.
  * @route GET /comments/:id
- * @param {number} id.path - the comment id
+ * @param {number} id.path.required - The comment id
  * @group Comments - Operations about comments
  * @operationId getComment
- * @returns {CommentResponse.model} 200 - The comment with the corresponding id
- * @returns {Error.model}  500 - Unexpected error
+ * @returns {ApiResponseSingleComment.model} 200 - The comment with the corresponding id
+ * @returns {ApiResponseError.model}  500 - Unexpected error in the backend...
  */
 router.get("/comments/:id", controllers.comments.get);
 
 /**
  * Edit a specific comment.
  * @route PATCH /comments/:id
- * @param {number} id.path - the comment id
- * @param {CommentRequest.model} comment.body.required - the edited comment
+ * @param {number} id.path.required - The comment id
+ * @param {ApiRequestComment.model} comment.body.required - The edited comment
  * @group Comments - Operations about comments
  * @operationId editComment
- * @returns {CommentResponse.model} 200 - The edited comment stored in the database
- * @returns {Error.model}  400 - Schema validation error
- * @returns {Error.model}  500 - Unexpected error
+ * @returns {ApiResponseSingleComment.model} 200 - The edited comment stored in the database
+ * @returns {ApiResponseError.model}  400 - Schema validation error
+ * @returns {ApiResponseError.model}  500 - Unexpected error in the backend...
  */
 router.patch("/comments/:id", controllers.comments.update);
 
 /**
  * Delete a specific comment.
  * @route DELETE /comments/:id
- * @param {number} id.path - the comment id
+ * @param {number} id.path.required - The comment id
  * @group Comments - Operations about comments
  * @operationId deleteComment
- * @returns {Response} 200 - Successful deletion
- * @returns {Error.model}  500 - Unexpected error
+ * @returns {ApiResponseSuccess.model} 200 - Successful deletion
+ * @returns {ApiResponseError.model}  500 - Unexpected error in the backend...
  */
 router.delete("/comments/:id", controllers.comments.delete);
 
 /**
  * Create a new child comment for the given comment.
  * @route POST /comments/:id/comment
- * @param {number} id.path - the comment id
- * @param {CommentRequest.model} comment.body.required - the new child comment for the given comment
+ * @param {number} id.path.required - The comment id
+ * @param {ApiRequestComment.model} comment.body.required - The new child comment for the given comment
  * @group Comments - Operations about comments
  * @operationId addChildComment
- * @returns {CommentResponse.model} 201 - The parent comment with the new child comment stored in the database
- * @returns {Error.model}  400 - Schema validation error
- * @returns {Error.model}  500 - Unexpected error
+ * @returns {ApiResponseSingleComment.model} 201 - The parent comment with the new child comment stored in the database
+ * @returns {ApiResponseError.model}  400 - Schema validation error
+ * @returns {ApiResponseError.model}  500 - Unexpected error in the backend...
  */
 router.post("/comments/:id/comment", controllers.comments.comment);
 
@@ -151,9 +151,35 @@ router.use("/", (req, res, next) => {
 module.exports = router;
 
 /**
- * @typedef Error
+ * @typedef ApiResponseSuccess
+ * @property {string} status.required - "ok"
+ */
+
+/**
+ * @typedef ApiResponseError
  * @property {string} status.required - "error"
  * @property {string} error.required - the error message
+ */
+
+/**
+ * @typedef ApiRequestPost
+ * @property {string} [author]
+ * @property {string} [title]
+ * @property {string} [text]
+ * @property {number} [upVotes]
+ * @property {number} [downVotes]
+ */
+
+/**
+ * @typedef ApiResponseMultiplePosts
+ * @property {string} status.required - "ok"
+ * @property {PostResponse[]} posts.required
+ */
+
+/**
+ * @typedef ApiResponseSinglePost
+ * @property {string} status.required - "ok"
+ * @property {PostResponse.model} post.required
  */
 
 /**
@@ -170,12 +196,23 @@ module.exports = router;
  */
 
 /**
- * @typedef PostRequest
- * @property {string} author.required
- * @property {string} title.required
- * @property {string} text.required
+ * @typedef ApiRequestComment
+ * @property {string} [author]
+ * @property {string} [text]
  * @property {number} [upVotes]
  * @property {number} [downVotes]
+ */
+
+/**
+ * @typedef ApiResponseMultipleComments
+ * @property {string} status.required - "ok"
+ * @property {CommentResponse[]} comments.required
+ */
+
+/**
+ * @typedef ApiResponseSingleComment
+ * @property {string} status.required - "ok"
+ * @property {CommentResponse.model} comments.required
  */
 
 /**
@@ -188,12 +225,4 @@ module.exports = router;
  * @property {string} createdAt.required
  * @property {string} updatedAt.required
  * @property {CommentResponse[]} comments.required
- */
-
-/**
- * @typedef CommentRequest
- * @property {string} author.required
- * @property {string} text.required
- * @property {number} [upVotes]
- * @property {number} [downVotes]
  */

--- a/routes/index.js
+++ b/routes/index.js
@@ -7,7 +7,17 @@ router.get("/", (req, res) => {
     "Please visit https://github.com/GTBitsOfGood/bootcamp/tree/master/10_react_with_apis for directions on how to use this API"
   );
 });
+
+/**
+ * Get all posts on the server and their top-level comments.
+ * @route GET /posts
+ * @group Posts - Operations about posts
+ * @operationId getPosts
+ * @returns {Post[]} 200 - An array of posts
+ * @returns {Error}  500 - Unexpected error
+ */
 router.get("/posts", controllers.posts.index);
+
 router.post("/posts", controllers.posts.store);
 router.get("/posts/:id", controllers.posts.get);
 router.patch("/posts/:id", controllers.posts.update);
@@ -33,3 +43,22 @@ router.use("/", (req, res, next) => {
   return res.status(status).json(response);
 });
 module.exports = router;
+
+/**
+ * @typedef Post
+ * @property {string} author.required - The person who created the post
+ * @property {string} title.required - The title of the post
+ * @property {string} text.required - The content of the post
+ * @property {number} upVotes.required - The number of up votes
+ * @property {number} downVotes.required - The number of down votes
+ * @property {Comment[]} comments.required - An array of top-level comments for the post
+ */
+
+/**
+ * @typedef Comment
+ * @property {string} author.required - The person who created the comment
+ * @property {string} text.required - The content of the comment
+ * @property {number} upVotes.required - The number of up votes
+ * @property {number} downVotes.required - The number of down votes
+ * @property {Comment[]} comments.required - An array of children comments for this comment. Follows the same schema as this schema
+ */

--- a/routes/index.js
+++ b/routes/index.js
@@ -152,42 +152,42 @@ module.exports = router;
 
 /**
  * @typedef PostResponse
- * @property {string} id.required - The ID of the post
- * @property {string} author.required - The person who created the post
- * @property {string} title.required - The title of the post
- * @property {string} text.required - The content of the post
- * @property {number} upVotes.required - The number of up votes
- * @property {number} downVotes.required - The number of down votes
- * @property {string} createdAt.required - The created datetime
- * @property {string} updatedAt.required - The updated datetime
- * @property {CommentResponse[]} comments.required - An array of top-level comments for the post
+ * @property {string} id.required
+ * @property {string} author.required
+ * @property {string} title.required
+ * @property {string} text.required
+ * @property {number} upVotes.required
+ * @property {number} downVotes.required
+ * @property {string} createdAt.required
+ * @property {string} updatedAt.required
+ * @property {CommentResponse[]} comments.required
  */
 
 /**
  * @typedef PostRequest
- * @property {string} author.required - The person who created the post
- * @property {string} title.required - The title of the post
- * @property {string} text.required - The content of the post
- * @property {number} [upVotes] - The number of up votes
- * @property {number} [downVotes] - The number of down votes
+ * @property {string} author.required
+ * @property {string} title.required
+ * @property {string} text.required
+ * @property {number} [upVotes]
+ * @property {number} [downVotes]
  */
 
 /**
  * @typedef CommentResponse
- * @property {string} id.required - The ID of the comment
- * @property {string} author.required - The person who created the comment
- * @property {string} text.required - The content of the comment
- * @property {number} upVotes.required - The number of up votes
- * @property {number} downVotes.required - The number of down votes
- * @property {string} createdAt.required - The created datetime
- * @property {string} updatedAt.required - The updated datetime
- * @property {CommentResponse[]} comments.required - An array of children comments for this comment. Follows the same schema as this schema
+ * @property {string} id.required
+ * @property {string} author.required
+ * @property {string} text.required
+ * @property {number} upVotes.required
+ * @property {number} downVotes.required
+ * @property {string} createdAt.required
+ * @property {string} updatedAt.required
+ * @property {CommentResponse[]} comments.required
  */
 
 /**
  * @typedef CommentRequest
- * @property {string} author.required - The person who created the comment
- * @property {string} text.required - The content of the comment
- * @property {number} [upVotes] - The number of up votes
- * @property {number} [downVotes] - The number of down votes
+ * @property {string} author.required
+ * @property {string} text.required
+ * @property {number} [upVotes]
+ * @property {number} [downVotes]
  */

--- a/routes/index.js
+++ b/routes/index.js
@@ -3,62 +3,191 @@ const router = express.Router();
 const controllers = require("../controllers");
 
 router.get("/", (req, res) => {
-  res.send(
-    "Please visit https://github.com/GTBitsOfGood/bootcamp/tree/master/10_react_with_apis for directions on how to use this API"
-  );
+    res.send(
+        "Please visit https://github.com/GTBitsOfGood/bootcamp/tree/master/10_react_with_apis for directions on how to use this API"
+    );
 });
 
 /**
- * Get all posts on the server and their top-level comments.
+ * Get all posts on the server.
  * @route GET /posts
  * @group Posts - Operations about posts
  * @operationId getPosts
- * @returns {Post[]} 200 - An array of posts
+ * @returns {PostResponse[]} 200 - An array of posts
  * @returns {Error}  500 - Unexpected error
  */
 router.get("/posts", controllers.posts.index);
 
+/**
+ * Create a new post.
+ * @route POST /posts
+ * @param {PostRequest.model} post.body.required - the new post
+ * @group Posts - Operations about posts
+ * @operationId createPost
+ * @returns {PostResponse.model} 201 - The new post stored in the database
+ * @returns {Error}  400 - Schema validation error
+ * @returns {Error}  500 - Unexpected error
+ */
 router.post("/posts", controllers.posts.store);
+
+/**
+ * Get a specific post.
+ * @route GET /posts/:id
+ * @param {number} id.path - the post id
+ * @group Posts - Operations about posts
+ * @operationId getPost
+ * @returns {PostResponse.model} 200 - The post with the corresponding id
+ * @returns {Error}  500 - Unexpected error
+ */
 router.get("/posts/:id", controllers.posts.get);
+
+/**
+ * Edit a specific post.
+ * @route PATCH /posts/:id
+ * @param {number} id.path - the post id
+ * @param {PostRequest.model} post.body.required - the edited post
+ * @group Posts - Operations about posts
+ * @operationId editPost
+ * @returns {PostResponse.model} 200 - The edited post stored in the database
+ * @returns {Error}  400 - Schema validation error
+ * @returns {Error}  500 - Unexpected error
+ */
 router.patch("/posts/:id", controllers.posts.update);
+
+/**
+ * Delete a specific post.
+ * @route DELETE /posts/:id
+ * @param {number} id.path - the post id
+ * @group Posts - Operations about posts
+ * @operationId deletePost
+ * @returns {Response} 200 - Successful deletion
+ * @returns {Error}  500 - Unexpected error
+ */
 router.delete("/posts/:id", controllers.posts.delete);
+
+/**
+ * Create a new top-level comment for the given post.
+ * @route POST /posts/:id/comment
+ * @param {number} id.path - the post id
+ * @param {CommentRequest.model} comment.body.required - the new comment for the post
+ * @group Posts - Operations about posts
+ * @operationId addTopLevelComment
+ * @returns {PostResponse.model} 201 - The post with the new comment stored in the database
+ * @returns {Error}  400 - Schema validation error
+ * @returns {Error}  500 - Unexpected error
+ */
 router.post("/posts/:id/comment", controllers.posts.comment);
 
+/**
+ * Get all comments on the server.
+ * @route GET /comments
+ * @group Comments - Operations about comments
+ * @operationId getComments
+ * @returns {CommentResponse[]} 200 - An array of comments
+ * @returns {Error}  500 - Unexpected error
+ */
 router.get("/comments", controllers.comments.index);
+
+/**
+ * Get a specific comment.
+ * @route GET /comments/:id
+ * @param {number} id.path - the comment id
+ * @group Comments - Operations about comments
+ * @operationId getComment
+ * @returns {CommentResponse.model} 200 - The comment with the corresponding id
+ * @returns {Error}  500 - Unexpected error
+ */
 router.get("/comments/:id", controllers.comments.get);
+
+/**
+ * Edit a specific comment.
+ * @route PATCH /comments/:id
+ * @param {number} id.path - the comment id
+ * @param {CommentRequest.model} comment.body.required - the edited comment
+ * @group Comments - Operations about comments
+ * @operationId editComment
+ * @returns {CommentResponse.model} 200 - The edited comment stored in the database
+ * @returns {Error}  400 - Schema validation error
+ * @returns {Error}  500 - Unexpected error
+ */
 router.patch("/comments/:id", controllers.comments.update);
+
+/**
+ * Delete a specific comment.
+ * @route DELETE /comments/:id
+ * @param {number} id.path - the comment id
+ * @group Comments - Operations about comments
+ * @operationId deleteComment
+ * @returns {Response} 200 - Successful deletion
+ * @returns {Error}  500 - Unexpected error
+ */
 router.delete("/comments/:id", controllers.comments.delete);
+
+/**
+ * Create a new child comment for the given comment.
+ * @route POST /comments/:id/comment
+ * @param {number} id.path - the comment id
+ * @param {CommentRequest.model} comment.body.required - the new child comment for the given comment
+ * @group Comments - Operations about comments
+ * @operationId addChildComment
+ * @returns {CommentResponse.model} 201 - The parent comment with the new child comment stored in the database
+ * @returns {Error}  400 - Schema validation error
+ * @returns {Error}  500 - Unexpected error
+ */
 router.post("/comments/:id/comment", controllers.comments.comment);
 
 router.use("/", (req, res, next) => {
-  let status = 500;
-  let response = { status: "error", msg: "Internal Server Error" };
-  if (res.locals.data) {
-    response = { status: "ok", ...res.locals.data };
-    status = res.locals.status || 200;
-  } else if (res.locals.error) {
-    status = res.locals.status || 500;
-    response = { status: "error", ...res.locals.error };
-  }
-  return res.status(status).json(response);
+    let status = 500;
+    let response = {status: "error", msg: "Internal Server Error"};
+    if (res.locals.data) {
+        response = {status: "ok", ...res.locals.data};
+        status = res.locals.status || 200;
+    } else if (res.locals.error) {
+        status = res.locals.status || 500;
+        response = {status: "error", ...res.locals.error};
+    }
+    return res.status(status).json(response);
 });
 module.exports = router;
 
 /**
- * @typedef Post
+ * @typedef PostResponse
+ * @property {string} id.required - The ID of the post
  * @property {string} author.required - The person who created the post
  * @property {string} title.required - The title of the post
  * @property {string} text.required - The content of the post
  * @property {number} upVotes.required - The number of up votes
  * @property {number} downVotes.required - The number of down votes
- * @property {Comment[]} comments.required - An array of top-level comments for the post
+ * @property {string} createdAt.required - The created datetime
+ * @property {string} updatedAt.required - The updated datetime
+ * @property {CommentResponse[]} comments.required - An array of top-level comments for the post
  */
 
 /**
- * @typedef Comment
+ * @typedef PostRequest
+ * @property {string} author.required - The person who created the post
+ * @property {string} title.required - The title of the post
+ * @property {string} text.required - The content of the post
+ * @property {number} [upVotes] - The number of up votes
+ * @property {number} [downVotes] - The number of down votes
+ */
+
+/**
+ * @typedef CommentResponse
+ * @property {string} id.required - The ID of the comment
  * @property {string} author.required - The person who created the comment
  * @property {string} text.required - The content of the comment
  * @property {number} upVotes.required - The number of up votes
  * @property {number} downVotes.required - The number of down votes
- * @property {Comment[]} comments.required - An array of children comments for this comment. Follows the same schema as this schema
+ * @property {string} createdAt.required - The created datetime
+ * @property {string} updatedAt.required - The updated datetime
+ * @property {CommentResponse[]} comments.required - An array of children comments for this comment. Follows the same schema as this schema
+ */
+
+/**
+ * @typedef CommentRequest
+ * @property {string} author.required - The person who created the comment
+ * @property {string} text.required - The content of the comment
+ * @property {number} [upVotes] - The number of up votes
+ * @property {number} [downVotes] - The number of down votes
  */

--- a/routes/index.js
+++ b/routes/index.js
@@ -14,7 +14,7 @@ router.get("/", (req, res) => {
  * @group Posts - Operations about posts
  * @operationId getPosts
  * @returns {PostResponse[]} 200 - An array of posts
- * @returns {Error}  500 - Unexpected error
+ * @returns {Error.model}  500 - Unexpected error
  */
 router.get("/posts", controllers.posts.index);
 
@@ -25,8 +25,8 @@ router.get("/posts", controllers.posts.index);
  * @group Posts - Operations about posts
  * @operationId createPost
  * @returns {PostResponse.model} 201 - The new post stored in the database
- * @returns {Error}  400 - Schema validation error
- * @returns {Error}  500 - Unexpected error
+ * @returns {Error.model}  400 - Schema validation error
+ * @returns {Error.model}  500 - Unexpected error
  */
 router.post("/posts", controllers.posts.store);
 
@@ -37,7 +37,7 @@ router.post("/posts", controllers.posts.store);
  * @group Posts - Operations about posts
  * @operationId getPost
  * @returns {PostResponse.model} 200 - The post with the corresponding id
- * @returns {Error}  500 - Unexpected error
+ * @returns {Error.model}  500 - Unexpected error
  */
 router.get("/posts/:id", controllers.posts.get);
 
@@ -49,8 +49,8 @@ router.get("/posts/:id", controllers.posts.get);
  * @group Posts - Operations about posts
  * @operationId editPost
  * @returns {PostResponse.model} 200 - The edited post stored in the database
- * @returns {Error}  400 - Schema validation error
- * @returns {Error}  500 - Unexpected error
+ * @returns {Error.model}  400 - Schema validation error
+ * @returns {Error.model}  500 - Unexpected error
  */
 router.patch("/posts/:id", controllers.posts.update);
 
@@ -61,7 +61,7 @@ router.patch("/posts/:id", controllers.posts.update);
  * @group Posts - Operations about posts
  * @operationId deletePost
  * @returns {Response} 200 - Successful deletion
- * @returns {Error}  500 - Unexpected error
+ * @returns {Error.model}  500 - Unexpected error
  */
 router.delete("/posts/:id", controllers.posts.delete);
 
@@ -73,8 +73,8 @@ router.delete("/posts/:id", controllers.posts.delete);
  * @group Posts - Operations about posts
  * @operationId addTopLevelComment
  * @returns {PostResponse.model} 201 - The post with the new comment stored in the database
- * @returns {Error}  400 - Schema validation error
- * @returns {Error}  500 - Unexpected error
+ * @returns {Error.model}  400 - Schema validation error
+ * @returns {Error.model}  500 - Unexpected error
  */
 router.post("/posts/:id/comment", controllers.posts.comment);
 
@@ -84,7 +84,7 @@ router.post("/posts/:id/comment", controllers.posts.comment);
  * @group Comments - Operations about comments
  * @operationId getComments
  * @returns {CommentResponse[]} 200 - An array of comments
- * @returns {Error}  500 - Unexpected error
+ * @returns {Error.model}  500 - Unexpected error
  */
 router.get("/comments", controllers.comments.index);
 
@@ -95,7 +95,7 @@ router.get("/comments", controllers.comments.index);
  * @group Comments - Operations about comments
  * @operationId getComment
  * @returns {CommentResponse.model} 200 - The comment with the corresponding id
- * @returns {Error}  500 - Unexpected error
+ * @returns {Error.model}  500 - Unexpected error
  */
 router.get("/comments/:id", controllers.comments.get);
 
@@ -107,8 +107,8 @@ router.get("/comments/:id", controllers.comments.get);
  * @group Comments - Operations about comments
  * @operationId editComment
  * @returns {CommentResponse.model} 200 - The edited comment stored in the database
- * @returns {Error}  400 - Schema validation error
- * @returns {Error}  500 - Unexpected error
+ * @returns {Error.model}  400 - Schema validation error
+ * @returns {Error.model}  500 - Unexpected error
  */
 router.patch("/comments/:id", controllers.comments.update);
 
@@ -119,7 +119,7 @@ router.patch("/comments/:id", controllers.comments.update);
  * @group Comments - Operations about comments
  * @operationId deleteComment
  * @returns {Response} 200 - Successful deletion
- * @returns {Error}  500 - Unexpected error
+ * @returns {Error.model}  500 - Unexpected error
  */
 router.delete("/comments/:id", controllers.comments.delete);
 
@@ -131,8 +131,8 @@ router.delete("/comments/:id", controllers.comments.delete);
  * @group Comments - Operations about comments
  * @operationId addChildComment
  * @returns {CommentResponse.model} 201 - The parent comment with the new child comment stored in the database
- * @returns {Error}  400 - Schema validation error
- * @returns {Error}  500 - Unexpected error
+ * @returns {Error.model}  400 - Schema validation error
+ * @returns {Error.model}  500 - Unexpected error
  */
 router.post("/comments/:id/comment", controllers.comments.comment);
 
@@ -149,6 +149,12 @@ router.use("/", (req, res, next) => {
     return res.status(status).json(response);
 });
 module.exports = router;
+
+/**
+ * @typedef Error
+ * @property {string} status.required - "error"
+ * @property {string} error.required - the error message
+ */
 
 /**
  * @typedef PostResponse


### PR DESCRIPTION
**New Feature** and **Documentation**

⚠️**Breaking Changes**⚠️

## API Docs with OpenAPI 2.0 & Swagger UI

Used [express-swagger-generator](https://www.npmjs.com/package/express-swagger-generator) to:

- auto-generate the [OpenAPI Specification 2.0](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md) via JS-Doc style comments in `routes.js`
- display the spec using Swagger UI on the `/api-docs` endpoint

## Breaking Changes

All pre-existing routes have been moved to `/api/v1` to follow OpenAPI conventions.

## User Experience

Viewable at the `/api-docs` endpoint

![image](https://user-images.githubusercontent.com/11142171/54320601-e7b74e00-45c3-11e9-8fb4-9021eb24a992.png)

